### PR TITLE
Removed the jQuery packages from the list

### DIFF
--- a/src/FilesCollector/AppSettings.json
+++ b/src/FilesCollector/AppSettings.json
@@ -20,8 +20,6 @@
       "Microsoft.AspNet.WebPages.Data",
       "Microsoft.AspNet.WebPages.OAuth",
       "Microsoft.AspNet.WebPages.WebData",
-      "Microsoft.jQuery.Unobtrusive.Ajax",
-      "Microsoft.jQuery.Unobtrusive.Validation",
       "MvcDiagnostics"
     ],
     "LangFoldersToProcess": [


### PR DESCRIPTION
Removed the `Microsoft.jQuery.Unobtrusive.Ajax` and `Microsoft.jQuery.Unobtrusive.Validation` packages from the list, as those will be shipped on their own cadance